### PR TITLE
add an adapter API; add logic for resetting test db

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,21 @@ Use Assert for testing Rails applications.  See https://github.com/redding/asser
 
 ## Usage
 
-TODO: Write code samples and usage instructions here
+In general, you should never bundle or require this gem directly.  This gem only houses the framework for testing Rails apps using Assert.
+
+Instead you should bundle/require one of the AssertRails adapter gems.  These adapter gems contain all the specific logic for each major version of Rails.  These gems, in turn, will require in this gem and use its common framework.
+
+See the usage instructions for the adapter gem you need:
+
+* Rails 4: https://github.com/redding/assert-rails4#usage
 
 ## Installation
 
-Add this line to your application's Gemfile:
+See the installation instructions for the adapter gem you need:
 
-    gem 'assert-rails'
+* Rails 4: https://github.com/redding/assert-rails4#installation
 
-And then execute:
-
-    $ bundle
-
-Or install it yourself as:
+If, for some reason, you want to just install this gem directly:
 
     $ gem install assert-rails
 

--- a/lib/assert-rails.rb
+++ b/lib/assert-rails.rb
@@ -1,4 +1,28 @@
 require "assert-rails/version"
 
 module AssertRails
+
+  def self.adapter(instance = nil)
+    @adapter = instance if !instance.nil?
+    @adapter
+  end
+
+  def self.reset_db
+    @reset_db ||= begin
+      self.reset_db!
+      true
+    end
+  end
+
+  def self.reset_db!
+    self.adapter.reset_db
+  end
+
+  class DefaultAdapter
+    include AssertRails::Adapter
+
+  end
+
+  self.adapter(DefaultAdapter.new)
+
 end

--- a/lib/assert-rails/adapter.rb
+++ b/lib/assert-rails/adapter.rb
@@ -1,0 +1,11 @@
+module AssertRails
+
+  module Adapter
+
+    def reset_db
+      raise NotImplementedError
+    end
+
+  end
+
+end

--- a/test/unit/adapter_tests.rb
+++ b/test/unit/adapter_tests.rb
@@ -1,0 +1,33 @@
+require "assert"
+require "assert-rails/adapter"
+
+module AssertRails::Adapter
+
+  class UnitTests < Assert::Context
+    desc "AssertRails::Adapter"
+    setup do
+      @module = AssertRails::Adapter
+    end
+    subject{ @module }
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      adapter_class = Class.new do
+        include AssertRails::Adapter
+      end
+      @adapter = adapter_class.new
+    end
+    subject{ @adapter }
+
+    should have_imeths :reset_db
+
+    should "not implement its adapter methods" do
+      assert_raises(NotImplementedError){ subject.reset_db }
+    end
+
+  end
+
+end

--- a/test/unit/assert-rails_tests.rb
+++ b/test/unit/assert-rails_tests.rb
@@ -1,0 +1,91 @@
+require "assert"
+require "assert-rails"
+
+module AssertRails
+
+  class UnitTests < Assert::Context
+    desc "AssertRails"
+    setup do
+      @module = AssertRails
+    end
+    subject{ @module }
+
+    should have_imeths :adapter
+    should have_imeths :reset_db, :reset_db!
+
+    should "set the DefaultAdapter as its adapter by default" do
+      assert_instance_of DefaultAdapter, AssertRails.adapter
+    end
+
+    should "call to the adapter for its adapter methods" do
+      assert_raises(NotImplementedError){ subject.reset_db }
+    end
+
+  end
+
+  class ResetDbTests < UnitTests
+    desc "when resetting the db"
+    setup do
+      @adapter_spy = AdapterSpy.new
+      Assert.stub(AssertRails, :adapter){ @adapter_spy }
+    end
+
+    should "run adapter cmds to reset the db only once" do
+      assert_equal [], @adapter_spy.cmds_called
+
+      subject.reset_db
+
+      exp = ["reset_db"]
+      assert_equal exp, @adapter_spy.cmds_called
+
+      subject.reset_db
+
+      exp = ["reset_db"]
+      assert_equal exp, @adapter_spy.cmds_called
+    end
+
+    should "force re-run adapter cmds to reset the db" do
+      assert_equal [], @adapter_spy.cmds_called
+
+      subject.reset_db!
+
+      exp = ["reset_db"]
+      assert_equal exp, @adapter_spy.cmds_called
+
+      subject.reset_db!
+
+      exp = ["reset_db", "reset_db"]
+      assert_equal exp, @adapter_spy.cmds_called
+    end
+
+  end
+
+  class DefaultAdapterTests < UnitTests
+    desc "DefaultAdapter"
+    setup do
+      @class = DefaultAdapter
+    end
+    subject{ @class }
+
+    should "mixin AssertRails::Adapter" do
+      assert_includes AssertRails::Adapter, subject
+    end
+
+  end
+
+  class AdapterSpy
+    include AssertRails::Adapter
+
+    attr_reader :cmds_called
+
+    def initialize
+      @cmds_called = []
+    end
+
+    def reset_db
+      self.cmds_called << "reset_db"
+    end
+
+  end
+
+end


### PR DESCRIPTION
This allows us to roll adapter gems for each major version of
Rails but still keep a common set of framework code in this gem.

This also defines the adapter API method for resetting test dbs
in test suites.

Usage:

In `Gemfile`:
```ruby
gem "assert-rails5"
```

In `test/helper.rb`:
```ruby
ENV['RAILS_ENV'] ||= 'test'
require_relative '../config/environment'

require "assert-rails5"
AssertRails.reset_db
```

@jcredding ready for review.