### PR TITLE
add Assert context for running database tests in a transaction

### DIFF
--- a/lib/assert-rails.rb
+++ b/lib/assert-rails.rb
@@ -1,4 +1,6 @@
 require "assert-rails/version"
+require "assert-rails/adapter"
+require "assert-rails/db_tests"
 
 module AssertRails
 
@@ -16,6 +18,14 @@ module AssertRails
 
   def self.reset_db!
     self.adapter.reset_db
+  end
+
+  def self.transaction(&block)
+    self.adapter.transaction(&block)
+  end
+
+  def self.rollback!
+    self.adapter.rollback!
   end
 
   class DefaultAdapter

--- a/lib/assert-rails/adapter.rb
+++ b/lib/assert-rails/adapter.rb
@@ -6,6 +6,14 @@ module AssertRails
       raise NotImplementedError
     end
 
+    def transaction(&block)
+      raise NotImplementedError
+    end
+
+    def rollback!
+      raise NotImplementedError
+    end
+
   end
 
 end

--- a/lib/assert-rails/db_tests.rb
+++ b/lib/assert-rails/db_tests.rb
@@ -1,0 +1,15 @@
+require "assert"
+require "assert-rails"
+
+module AssertRails
+
+  class DbTests < Assert::Context
+    around do |block|
+      AssertRails.transaction do
+        block.call
+        AssertRails.rollback!
+      end
+    end
+  end
+
+end

--- a/test/unit/adapter_tests.rb
+++ b/test/unit/adapter_tests.rb
@@ -23,9 +23,12 @@ module AssertRails::Adapter
     subject{ @adapter }
 
     should have_imeths :reset_db
+    should have_imeths :transaction, :rollback!
 
     should "not implement its adapter methods" do
       assert_raises(NotImplementedError){ subject.reset_db }
+      assert_raises(NotImplementedError){ subject.transaction }
+      assert_raises(NotImplementedError){ subject.rollback! }
     end
 
   end

--- a/test/unit/assert-rails_tests.rb
+++ b/test/unit/assert-rails_tests.rb
@@ -12,6 +12,7 @@ module AssertRails
 
     should have_imeths :adapter
     should have_imeths :reset_db, :reset_db!
+    should have_imeths :transaction, :rollback!
 
     should "set the DefaultAdapter as its adapter by default" do
       assert_instance_of DefaultAdapter, AssertRails.adapter
@@ -19,6 +20,8 @@ module AssertRails
 
     should "call to the adapter for its adapter methods" do
       assert_raises(NotImplementedError){ subject.reset_db }
+      assert_raises(NotImplementedError){ subject.transaction }
+      assert_raises(NotImplementedError){ subject.rollback! }
     end
 
   end

--- a/test/unit/db_tests_tests.rb
+++ b/test/unit/db_tests_tests.rb
@@ -1,0 +1,42 @@
+require "assert"
+require "assert-rails/db_tests"
+
+class AssertRails::DbTests
+
+  class UnitTests < Assert::Context
+    desc "AssertRails::DbTests"
+    setup do
+      @transaction_called = false
+      Assert.stub(AssertRails, :transaction) do |&block|
+        @transaction_called = true
+        block.call
+      end
+
+      @rollback_called = false
+      Assert.stub(AssertRails, :rollback!) do
+        @rollback_called = true
+      end
+
+      @class = AssertRails::DbTests
+    end
+    subject{ @class }
+
+    should "be an Assert context" do
+      assert subject < Assert::Context
+    end
+
+    should "add an around callback to run tests in a rollback transaction" do
+      assert_equal 1, subject.arounds.size
+      callback = subject.arounds.first
+
+      block_yielded_to = false
+      callback.call(proc{ block_yielded_to = true })
+
+      assert_true @transaction_called
+      assert_true @rollback_called
+      assert_true block_yielded_to
+    end
+
+  end
+
+end


### PR DESCRIPTION
This adds a `DbTests` Assert context that has an `around` block
for running tests in a transaction and rolling them back after the
tests have run.

This allows not only speeds up your tests b/c you are not actually
persisting any data, it also allows you to do parallel test runs
b/c the database interactions are now multi-process safe because
of the transactions.

All of the ActiveRecord interactions are behind the adapter so
this just tests the adapter API.  In this case, I doubt the
ActiveRecord interactions will change over major versions (ie the
`transaction` and `rollback` apis are pretty stable), a design
principal is this gem cannot directly require ActiveRecord.
Therefore, all interactions must be behind the adapters.

@jcredding ready for review.